### PR TITLE
allow users to double/triple click to highlight card text

### DIFF
--- a/components/card/Card.jsx
+++ b/components/card/Card.jsx
@@ -12,6 +12,7 @@ const baseCardContainer = css`
     margin-bottom: 1rem;
     padding: 0.5rem 1rem;
     border: 1px solid ${ colors.black };
+    user-select: text;
 
     form {
         margin: 0;


### PR DESCRIPTION
Fixes #24. Users should now be able to double/triple click to select text inside of a card. You still can't drag select but this should be good enough for now.