### PR TITLE
Fix A-Z button to sort boards in ascending order

### DIFF
--- a/components/boards/Boards.jsx
+++ b/components/boards/Boards.jsx
@@ -67,8 +67,10 @@ class Boards extends Component {
 
     handleSortChange = (key, direction) => {
         if (this.state.sortKey !== key) {
-            this.setState({ sortKey: key })
-            this.setState({ sortDirection: direction })
+            this.setState({
+                sortKey: key,
+                sortDirection: direction
+            })
             this.props.load(key, direction)
         }
     }

--- a/components/boards/Boards.jsx
+++ b/components/boards/Boards.jsx
@@ -57,17 +57,19 @@ const styles = {
 
 class Boards extends Component {
     state = {
-        sortKey: 'last_update_time'
+        sortKey: 'last_update_time',
+        sortDirection: 'DESC'
     }
 
     componentDidMount() {
-        this.props.load('last_update_time')
+        this.props.load('last_update_time', 'DESC')
     }
 
-    handleSortChange = key => {
+    handleSortChange = (key, direction) => {
         if (this.state.sortKey !== key) {
             this.setState({ sortKey: key })
-            this.props.load(key)
+            this.setState({ sortDirection: direction })
+            this.props.load(key, direction)
         }
     }
 
@@ -82,8 +84,8 @@ class Boards extends Component {
                     <div className={ styles.header }>
                         <h1 className={ styles.headerText }>Nic Cage</h1>
                         <div className={ styles.actions }>
-                            <a className={ cx(styles.action, { [styles.activeSort]: sortKey === 'last_update_time' }) } onClick={ () => this.handleSortChange('last_update_time') }>Most Recent</a> 
-                            <a className={ cx(styles.action, { [styles.activeSort]: sortKey === 'content.name' }) } onClick={ () => this.handleSortChange('content.name') }>A-Z</a>
+                            <a className={ cx(styles.action, { [styles.activeSort]: sortKey === 'last_update_time' }) } onClick={ () => this.handleSortChange('last_update_time', 'DESC') }>Most Recent</a>
+                            <a className={ cx(styles.action, { [styles.activeSort]: sortKey === 'content.name' }) } onClick={ () => this.handleSortChange('content.name', 'ASC') }>A-Z</a>
                             <button className={ cx(styles.action, baseButton, styles.editButton) } onClick={ onEditBoards }>{ isEditingBoards ? 'Done' : 'Edit' }</button>
                         </div>
                     </div>

--- a/containers/BoardsContainer.js
+++ b/containers/BoardsContainer.js
@@ -11,8 +11,8 @@ const mapStateToProps = (state, ownProps) => ({
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-    load: sortKey => {
-        dispatch(updateBoardsSearchDefinition(sortKey, 'DESC', ownProps.match.params.id))
+    load: (sortKey, sortDirection) => {
+        dispatch(updateBoardsSearchDefinition(sortKey, sortDirection, ownProps.match.params.id))
         dispatch(getBoards(sortKey, ownProps.match.params.id))
     },
     onDelete: id => dispatch(deleteBoard(id)),


### PR DESCRIPTION
A-Z button was sorting in descending order. This change ensures we sort board names in ascending order.